### PR TITLE
Updates the widget selector example in the README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ Use this selector to target Widgets.
 use Guava\Tutorials\Selectors\WidgetSelector;
 
 // Currently only the "index" of the widget is supported
-// So first widget = 1, second widget = 2, etc.
-Step::make(WidgetSelector::make(1));
+// So first widget = '1', second widget = '2', etc.
+Step::make(WidgetSelector::make('1'));
 ```
 
 #### (Generic) Selector


### PR DESCRIPTION
The selector needs to be a string [based on the method implementation](https://github.com/GuavaCZ/tutorials/blob/01daa2f00d5d530fd4ce8ac598e0c93c5ccf87a3/src/Selectors/Selector.php#L22).

```php
public static function make(string $selector)
{
    return app(static::class, [
        'selector' => $selector,
    ]);
}
```