### PR TITLE
Adds Closure to the actions' property types.

### DIFF
--- a/src/Concerns/HasActions.php
+++ b/src/Concerns/HasActions.php
@@ -17,13 +17,13 @@ trait HasActions
      */
     protected null | array | Closure $actions = null;
 
-    protected ?TutorialAction $previousStepAction = null;
+    protected null | Closure | TutorialAction $previousStepAction = null;
 
-    protected ?TutorialAction $nextStepAction = null;
+    protected null | Closure | TutorialAction $nextStepAction = null;
 
-    protected ?TutorialAction $skipTutorialAction = null;
+    protected null | Closure | TutorialAction $skipTutorialAction = null;
 
-    protected ?TutorialAction $completeTutorialAction = null;
+    protected null | Closure | TutorialAction $completeTutorialAction = null;
 
     /**
      * @var array<TutorialAction>|Closure


### PR DESCRIPTION
When trying to use a `Closure` for customizing the actions, it throws a TypeError: "Cannot assign Closure to property Guava\Tutorials\Steps\Step::$nextStepAction of type ?Guava\Tutorials\Filament\TutorialAction"

```php
Step::make('docs')
    ->nextStepAction(
        fn (NextStepAction $action) => $action->icon('heroicon-o-document-text')
    ),
```

As mentioned in the [Customizing actions](https://github.com/GuavaCZ/tutorials/blob/main/README.md#customizing-actions) section, all four actions accept `Closure`. Therefore, the corresponding properties should also include `Closure` in their types.

```php
public function nextStepAction(TutorialAction | Closure | null $action): static
{
    $this->nextStepAction = $action;

    return $this;
}
```