### PR TITLE
Ensures proper alignment in both LTR and RTL layouts

### DIFF
--- a/resources/views/components/step/actions.blade.php
+++ b/resources/views/components/step/actions.blade.php
@@ -3,7 +3,7 @@
     'color' => null,
 ])
 @if(!empty($actions))
-    <div class="ml-auto flex flex-row flex-wrap gap-2">
+    <div class="ms-auto flex flex-row flex-wrap gap-2">
         @foreach($actions as $action)
             <div @class([
                     '[&_button]:!bg-custom-400',

--- a/resources/views/components/step/hint.blade.php
+++ b/resources/views/components/step/hint.blade.php
@@ -3,5 +3,5 @@
 ])
 
 @if($hint)
-    <span class="ml-auto">{{ $hint }}</span>
+    <span class="ms-auto">{{ $hint }}</span>
 @endif


### PR DESCRIPTION
The `ml-auto` class only applies margin to the left, which works for LTR languages. By switching to `ms-auto`, the alignment will now dynamically adjust for RTL layouts as well, improving the user experience for languages like Persian and Arabic.

Here is the existing layout with the `ml-auto`:

![Screenshot from 2024-09-10 23-38-51](https://github.com/user-attachments/assets/e1b146d5-552e-4368-8a4e-1bfc4b87c179)

Here is the updated layout with the `ms-auto` applied to the `hint` blade component:

![Screenshot from 2024-09-10 23-39-05](https://github.com/user-attachments/assets/04f1f58b-f3dc-423d-a8c4-482833d07667)

Here is the final layout with the `ms-auto` applied to the `hint` and `actions` blade components:

![Screenshot from 2024-09-10 23-39-30](https://github.com/user-attachments/assets/e128a1a5-e2eb-4c04-9338-92fbf125ee07)
